### PR TITLE
Use more compatible values in the Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 CFLAGS := $(CFLAGS) `pkg-config ncursesw jansson --cflags` \
-	-std=c11 -Wall -Wextra -Wpedantic -pipe
+	-std=gnu11 -Wall -Wextra -Wpedantic -pipe
 LDFLAGS ?= -Wl,-O1 -Wl,--as-needed -Wl,-flto
 LIBS := `pkg-config ncursesw jansson --libs`
 
@@ -7,7 +7,7 @@ SRCS := $(wildcard *.c)
 OBJS := $(SRCS:.c=.o)
 
 OPTLEVEL ?= -O3 -march=native -flto
-prefix ?= /usr/local
+PREFIX ?= /usr/local
 
 %.o: %.c
 	$(CC) $(CFLAGS) $(OPTLEVEL) -c $<
@@ -24,4 +24,4 @@ clean:
 
 .PHONY: install
 install: all
-	install -m 0755 wr $(prefix)/bin
+	install -Dm 0755 wr $(PREFIX)/bin/worstrun


### PR DESCRIPTION
I'm making a worstrun NixOS package, and this is the stuff I had to patch to make it build.

* uppercase PREFIX (this is more like a convention)
* executable inside PREFIX/bin
* std=gnu11 for time stuff (otherwise clock_gettime isn't exposed. there are other solutions for this, not sure if this one is best)